### PR TITLE
Added property to access the tags in a subscription as a symbolized hash

### DIFF
--- a/lib/fastspring-saasy/subscription.rb
+++ b/lib/fastspring-saasy/subscription.rb
@@ -49,6 +49,20 @@ module FastSpring
       value_for('quantity').to_i
     end
 
+    def tags
+      begin
+        fs_tags = value_for('tags')
+        result = {}
+        fs_tags.split(",").each do |t| 
+           k,v = t.strip.split('=')
+           result[k.to_sym] = v
+        end
+        result
+      rescue 
+        nil
+      end
+    end
+
     def customer_url
       value_for('customerUrl')
     end

--- a/spec/fixtures/basic_subscription.xml
+++ b/spec/fixtures/basic_subscription.xml
@@ -18,7 +18,7 @@
   </customer>
   <customerUrl/>
   <productName>Acme Inc Web</productName>
-  <tags/>
+  <tags>number1=1, number2=2</tags>
   <quantity>0</quantity>
   <nextPeriodDate>2010-08-15Z</nextPeriodDate>
   <end>2010-08-15Z</end>

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -85,6 +85,11 @@ describe FastSpring::Subscription do
     it 'returns the end date' do
       subject.ends_on.should be_an_instance_of(Date)
     end
+    
+    it 'returns the tags as a symbolized hash' do
+      subject.tags[:number1].should == "1"
+      subject.tags[:number2].should == "2"
+    end
   end
 
   context 'create subscriptions path' do


### PR DESCRIPTION
Hi Richard,

I have added the tags property to the subscription class, which returns tags as a symbolized hash. I hope you find this update useful to put into the main repo.

Thanks,

Pascal
